### PR TITLE
FIX torch MP bug on Linux

### DIFF
--- a/peptdeep/pretrained_models.py
+++ b/peptdeep/pretrained_models.py
@@ -45,6 +45,9 @@ from peptdeep.utils import (
 
 from peptdeep.settings import global_settings, update_global_settings
 
+import torch.multiprocessing
+torch.multiprocessing.set_sharing_strategy('file_system')
+
 pretrain_dir = os.path.join(
     os.path.join(
         os.path.expanduser(


### PR DESCRIPTION
Mitigates too many open files error using MP on linux.
See: [Issue](https://github.com/pytorch/pytorch/issues/11201)
