### PR TITLE
FIX use Lumos model for Astral

### DIFF
--- a/peptdeep/constants/default_settings.yaml
+++ b/peptdeep/constants/default_settings.yaml
@@ -81,7 +81,7 @@ model_mgr:
   use_predicted_charge_in_speclib: True # if True, it ignores min/max_precursor_charge in `library`
   instrument_group:
     ThermoTOF: ThermoTOF
-    Astral: ThermoTOF
+    Astral: Lumos
     Lumos: Lumos
     QE: QE
     timsTOF: timsTOF


### PR DESCRIPTION
As discussed the Astral model has not been properly trained and is not yet showing great performance.
For alphaDIA users it's very confusing to not select the Astral but the Lumos model.

I propose therefore to substitute it in peptDeep as long as we don't have a Astral model.