### PR TITLE
add new release workflow action

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,23 @@
+# Create a draft release and build and upload all installers to it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_to_release:
+        description: 'Enter commit hash to release (example: ef4037cb571f99cb4919b520fde7174972aae473)'
+        type: string
+        required: true
+      tag_to_release:
+        description: 'Enter tag to release (example: v1.5.5)'
+        type: string
+        required: true
+
+jobs:
+  create-release:
+    uses: MannLabs/alphashared/.github/workflows/create-release.yml@v1
+    with:
+      package_name: peptdeep
+      build_nodejs_ui: false
+      commit_to_release: ${{ inputs.commit_to_release }}
+      tag_to_release: ${{ inputs.tag_to_release }}
+    secrets: inherit


### PR DESCRIPTION
Add new release workflow. 

Needs to go directly to `main` in order to be active for testing.