### PR TITLE
allow partial loading for pre trained ms2 models

### DIFF
--- a/peptdeep/model/ms2.py
+++ b/peptdeep/model/ms2.py
@@ -424,6 +424,7 @@ class pDeepModel(model_interface.ModelInterface):
         self.frag_inten_df = fragment_intensity_df[self.charged_frag_types]
         # if np.all(precursor_df['nce'].values > 1):
         #     precursor_df['nce'] = precursor_df['nce']*self.NCE_factor
+
     def _load_model_from_stream(self, stream: IO):
         """
         Overriding this function to allow for partial loading of pretrained models.
@@ -454,11 +455,22 @@ class pDeepModel(model_interface.ModelInterface):
         self.model.load_state_dict(filtered_params, strict=False)
         if size_mismatches or unexpected_keys or missing_keys:
             warning_msg = "Some layers might be randomly initialized due to a mismatch between the loaded weights and the model architecture. Make sure to train the model or load different weights before prediction."
-            warning_msg += f" The following keys had size mismatches: {size_mismatches}" if size_mismatches else ""
-            warning_msg += f" The following keys were unexpected: {unexpected_keys}" if unexpected_keys else ""
-            warning_msg += f" The following keys were missing: {missing_keys}" if missing_keys else ""
+            warning_msg += (
+                f" The following keys had size mismatches: {size_mismatches}"
+                if size_mismatches
+                else ""
+            )
+            warning_msg += (
+                f" The following keys were unexpected: {unexpected_keys}"
+                if unexpected_keys
+                else ""
+            )
+            warning_msg += (
+                f" The following keys were missing: {missing_keys}"
+                if missing_keys
+                else ""
+            )
             logging.warning(warning_msg)
-
 
     def _check_predict_in_order(self, precursor_df: pd.DataFrame):
         pass

--- a/peptdeep/pretrained_models.py
+++ b/peptdeep/pretrained_models.py
@@ -270,7 +270,7 @@ class ModelManager(object):
         self,
         mask_modloss: bool = False,
         device: str = "gpu",
-        charged_frag_types: list[str]= None
+        charged_frag_types: list[str] = None,
     ):
         """
         Parameters
@@ -285,14 +285,20 @@ class ModelManager(object):
             if device=='gpu' but no GPUs are detected, it will automatically switch to 'cpu'.
             Defaults to 'gpu'
         charge_frag_types : list[str], optional
-            Charge fragment types for MS2 model to override the default configuration in the yaml file. 
+            Charge fragment types for MS2 model to override the default configuration in the yaml file.
             If set to None, it will use the default configuration in the yaml file.
         """
         self._train_psm_logging = True
 
-        self.ms2_model: pDeepModel = pDeepModel(
-            mask_modloss=mask_modloss, device=device
-        ) if charged_frag_types is None else pDeepModel(mask_modloss=mask_modloss, device=device, charged_frag_types=charged_frag_types)
+        self.ms2_model: pDeepModel = (
+            pDeepModel(mask_modloss=mask_modloss, device=device)
+            if charged_frag_types is None
+            else pDeepModel(
+                mask_modloss=mask_modloss,
+                device=device,
+                charged_frag_types=charged_frag_types,
+            )
+        )
         self.rt_model: AlphaRTModel = AlphaRTModel(device=device)
         self.ccs_model: AlphaCCSModel = AlphaCCSModel(device=device)
         self.load_installed_models()


### PR DESCRIPTION
This PR include two main changes:
- Allow to dynamically change the charged_frag_types used for ms2 hence changing the dimensions of the output layer for the ms2 model. 
- Allow for partially loading the ms2 model so that a user can benefit from a pretrained model backbone when using a different prediction head such as changing the fragment types. With this feature users can finetune/train a model with more fragment types than the ones used from for pretraining. From my experiments using a pretrained backbone had a significant performance gap compared to training fully from scratch. 

From an alphaDia finetuning experiment where I want to predict the following fragment types `['b','y','c','a','x','z']`
- Performance when training for 50 epochs from scratch:
```
Model tested on test dataset with the following metrics:

l1_loss                       : 0.0228
PCC-mean                      : 0.8015
COS-mean                      : 0.8140
SA-mean                       : 0.6054
SPC-mean                      : -0.2333
```
 - Performance when training for 50 epochs when loading a pretrained backbone:
```
Model tested on test dataset with the following metrics:

l1_loss                       : 0.0122
PCC-mean                      : 0.9462
COS-mean                      : 0.9491
SA-mean                       : 0.7961
SPC-mean                      : -0.3072
```